### PR TITLE
removing the webrockit-api jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ tmp
 Gemfile.lock
 config/config.yml
 
+webrockit-api.jar
+
 # YARD artifacts
 .yardoc
 _yardoc


### PR DESCRIPTION
Removing the webrockit-api jar file. Jar will be distributed via
rpms/yum.
